### PR TITLE
feat: add bezier control handles for linear elements

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -70,10 +70,27 @@ import type {
   ExcalidrawFreeDrawElement,
   ElementsMap,
   ExcalidrawLineElement,
+  BezierHandle,
 } from "./types";
 
 import type { Drawable, Options } from "roughjs/bin/core";
 import type { Point as RoughPoint } from "roughjs/bin/geometry";
+
+export const generateCubicBezierPath = (
+  points: readonly LocalPoint[],
+  handles: readonly BezierHandle[],
+) => {
+  if (points.length === 0) {
+    return "";
+  }
+  let d = `M${points[0][0]} ${points[0][1]}`;
+  for (let i = 0; i < handles.length && i < points.length - 1; i++) {
+    const [cp1, cp2] = handles[i];
+    const [x, y] = points[i + 1];
+    d += ` C${cp1[0]} ${cp1[1]} ${cp2[0]} ${cp2[1]} ${x} ${y}`;
+  }
+  return d;
+};
 
 export class ShapeCache {
   private static rg = new RoughGenerator();
@@ -749,6 +766,13 @@ const generateElementShape = (
             ),
           ];
         }
+      } else if (element.controlHandles && element.controlHandles.length > 0) {
+        shape = [
+          generator.path(
+            generateCubicBezierPath(points, element.controlHandles),
+            options,
+          ),
+        ];
       } else if (!element.roundness) {
         // curve is always the first element
         // this simplifies finding the curve for an element

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -318,6 +318,8 @@ export type Arrowhead =
   | "crowfoot_many"
   | "crowfoot_one_or_many";
 
+export type BezierHandle = readonly [LocalPoint, LocalPoint];
+
 export type ExcalidrawLinearElement = _ExcalidrawElementBase &
   Readonly<{
     type: "line" | "arrow";
@@ -327,6 +329,8 @@ export type ExcalidrawLinearElement = _ExcalidrawElementBase &
     endBinding: PointBinding | null;
     startArrowhead: Arrowhead | null;
     endArrowhead: Arrowhead | null;
+    /** Cubic bezier control handles for each segment */
+    controlHandles?: readonly BezierHandle[];
   }>;
 
 export type ExcalidrawLineElement = ExcalidrawLinearElement &

--- a/packages/element/tests/bezierPath.test.ts
+++ b/packages/element/tests/bezierPath.test.ts
@@ -1,0 +1,12 @@
+import { generateCubicBezierPath } from "../src/shape";
+import { pointFrom, type LocalPoint } from "@excalidraw/math";
+
+describe("generateCubicBezierPath", () => {
+  it("returns path for cubic bezier", () => {
+    const points: readonly LocalPoint[] = [pointFrom(0, 0), pointFrom(10, 10)];
+    const handles = [[pointFrom(0, 10), pointFrom(10, 0)] as const];
+    expect(generateCubicBezierPath(points, handles)).toBe(
+      "M0 0 C0 10 10 0 10 10",
+    );
+  });
+});

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -342,6 +342,9 @@ const restoreElement = (
         points,
         x,
         y,
+        ...("controlHandles" in element && element.controlHandles
+          ? { controlHandles: element.controlHandles }
+          : {}),
         ...(isLineElement(element)
           ? {
               polygon: isValidPolygon(element.points)
@@ -376,6 +379,9 @@ const restoreElement = (
         x,
         y,
         elbowed: (element as ExcalidrawArrowElement).elbowed,
+        ...("controlHandles" in element && element.controlHandles
+          ? { controlHandles: element.controlHandles }
+          : {}),
         ...getSizeFromPoints(points),
       } as const;
 


### PR DESCRIPTION
## Summary
- support optional bezier control handles on linear elements
- render cubic bezier curves when control handles are present
- keep bezier control handles when restoring serialized data
- add unit test for cubic bezier path generation

## Testing
- `yarn test packages/element/tests/bezierPath.test.ts --run`
- `npx eslint packages/element/src/shape.ts packages/element/src/types.ts packages/excalidraw/data/restore.ts packages/element/tests/bezierPath.test.ts` *(fails: RangeError: path should be a `path.relative()`d string)*

------
https://chatgpt.com/codex/tasks/task_e_6895b1bcebd083238790ec438df2ce4b