### PR TITLE
Refactor mask coordinate transforms, update mask renderer, and add unit tests

### DIFF
--- a/packages/excalidraw/mask-editor/index.ts
+++ b/packages/excalidraw/mask-editor/index.ts
@@ -137,11 +137,9 @@ export class MaskEditor {
     return -1;
   }
 
-  static globalToImageLocal(
+  static globalToElementLocalDisplay(
     globalPoint: GlobalPoint,
     element: ExcalidrawImageElement,
-    naturalWidth: number,
-    naturalHeight: number,
   ): { x: number; y: number } {
     const cx = element.x + element.width / 2;
     const cy = element.y + element.height / 2;
@@ -161,6 +159,20 @@ export class MaskEditor {
     if (element.scale[1] < 0) {
       localY = element.height - localY;
     }
+
+    return { x: localX, y: localY };
+  }
+
+  static globalToImageLocal(
+    globalPoint: GlobalPoint,
+    element: ExcalidrawImageElement,
+    naturalWidth: number,
+    naturalHeight: number,
+  ): { x: number; y: number } {
+    const { x: localX, y: localY } = MaskEditor.globalToElementLocalDisplay(
+      globalPoint,
+      element,
+    );
 
     const normalizedX = localX / element.width;
     const normalizedY = localY / element.height;

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -1496,7 +1496,6 @@ const renderMaskEditor = (
   renderConfig: InteractiveCanvasRenderConfig,
   appState: InteractiveCanvasAppState,
   maskingElement: ExcalidrawImageElement,
-  elementsMap: ElementsMap,
 ): void => {
   const { maskingPoints, maskingMode, selectedMaskPointIndex, zoom } = appState;
   if (!maskingPoints || maskingPoints.length === 0) {
@@ -1506,20 +1505,22 @@ const renderMaskEditor = (
   try {
     context.save();
 
-    const [x1, y1, x2, y2] = getElementAbsoluteCoords(
-      maskingElement,
-      elementsMap,
-    );
-    const cx = (x1 + x2) / 2;
-    const cy = (y1 + y2) / 2;
-    const width = x2 - x1;
-    const height = y2 - y1;
+    const cx = maskingElement.x + maskingElement.width / 2;
+    const cy = maskingElement.y + maskingElement.height / 2;
+    const width = maskingElement.width;
+    const height = maskingElement.height;
 
-    const toLocalCoords = (p: readonly [number, number]) => {
-      return { x: p[0] - cx, y: p[1] - cy };
-    };
+    const savedLocalPoints = maskingPoints.map((point) => {
+      const localPoint = MaskEditor.globalToElementLocalDisplay(
+        point,
+        maskingElement,
+      );
 
-    const savedLocalPoints = maskingPoints.map(toLocalCoords);
+      return {
+        x: localPoint.x - width / 2,
+        y: localPoint.y - height / 2,
+      };
+    });
 
     // 绘制遮罩叠加层，用 clip 限制 destination-out 的范围
     context.save();
@@ -2047,13 +2048,7 @@ const _renderInteractiveScene = ({
         const maskingElement = elementsMap.get(appState.maskingElementId);
 
         if (maskingElement && isImageElement(maskingElement)) {
-          renderMaskEditor(
-            context,
-            renderConfig,
-            appState,
-            maskingElement,
-            elementsMap,
-          );
+          renderMaskEditor(context, renderConfig, appState, maskingElement);
         }
       }
     } else if (

--- a/packages/excalidraw/tests/maskEditor.test.ts
+++ b/packages/excalidraw/tests/maskEditor.test.ts
@@ -1,0 +1,122 @@
+import { newImageElement } from "@excalidraw/element";
+import { pointFrom, pointRotateRads, type Radians } from "@excalidraw/math";
+
+import type { ExcalidrawImageElement } from "@excalidraw/element/types";
+import type { GlobalPoint } from "@excalidraw/math";
+
+import { MaskEditor } from "../mask-editor";
+
+const globalPointFromPreviewLocal = (
+  element: ExcalidrawImageElement,
+  localX: number,
+  localY: number,
+): GlobalPoint => {
+  const cx = element.x + element.width / 2;
+  const cy = element.y + element.height / 2;
+
+  let displayX = localX;
+  let displayY = localY;
+
+  if (element.scale[0] < 0) {
+    displayX = element.width - displayX;
+  }
+  if (element.scale[1] < 0) {
+    displayY = element.height - displayY;
+  }
+
+  return pointRotateRads(
+    pointFrom<GlobalPoint>(element.x + displayX, element.y + displayY),
+    pointFrom<GlobalPoint>(cx, cy),
+    element.angle as Radians,
+  );
+};
+
+describe("MaskEditor coordinate transforms", () => {
+  it("keeps rotated preview path coordinates consistent with applyMask image coordinates", () => {
+    const element = newImageElement({
+      type: "image",
+      x: 120,
+      y: 80,
+      width: 200,
+      height: 100,
+      angle: (Math.PI / 5) as Radians,
+      scale: [1, 1],
+    });
+
+    const naturalWidth = 800;
+    const naturalHeight = 400;
+    const previewLocalPoints = [
+      { x: 20, y: 10 },
+      { x: 160, y: 15 },
+      { x: 130, y: 80 },
+      { x: 35, y: 75 },
+    ];
+    const maskingPoints = previewLocalPoints.map(({ x, y }) =>
+      globalPointFromPreviewLocal(element, x, y),
+    );
+
+    const previewPathPoints = maskingPoints.map((point) =>
+      MaskEditor.globalToElementLocalDisplay(point, element),
+    );
+    const applyMaskLocalPoints = maskingPoints.map((point) =>
+      MaskEditor.globalToImageLocal(
+        point,
+        element,
+        naturalWidth,
+        naturalHeight,
+      ),
+    );
+
+    previewPathPoints.forEach((previewPoint, index) => {
+      expect(previewPoint.x).toBeCloseTo(previewLocalPoints[index].x);
+      expect(previewPoint.y).toBeCloseTo(previewLocalPoints[index].y);
+      expect(applyMaskLocalPoints[index].x).toBeCloseTo(
+        (previewPoint.x / element.width) * naturalWidth,
+      );
+      expect(applyMaskLocalPoints[index].y).toBeCloseTo(
+        (previewPoint.y / element.height) * naturalHeight,
+      );
+    });
+  });
+
+  it("mirrors preview path coordinates the same way as applyMask image coordinates", () => {
+    const element = newImageElement({
+      type: "image",
+      x: -40,
+      y: 30,
+      width: 120,
+      height: 90,
+      angle: (Math.PI / 7) as Radians,
+      scale: [-1, -1],
+    });
+
+    const naturalWidth = 360;
+    const naturalHeight = 270;
+    const previewLocalPoint = { x: 25, y: 60 };
+    const maskingPoint = globalPointFromPreviewLocal(
+      element,
+      previewLocalPoint.x,
+      previewLocalPoint.y,
+    );
+
+    const previewPoint = MaskEditor.globalToElementLocalDisplay(
+      maskingPoint,
+      element,
+    );
+    const applyMaskPoint = MaskEditor.globalToImageLocal(
+      maskingPoint,
+      element,
+      naturalWidth,
+      naturalHeight,
+    );
+
+    expect(previewPoint.x).toBeCloseTo(previewLocalPoint.x);
+    expect(previewPoint.y).toBeCloseTo(previewLocalPoint.y);
+    expect(applyMaskPoint.x).toBeCloseTo(
+      (previewPoint.x / element.width) * naturalWidth,
+    );
+    expect(applyMaskPoint.y).toBeCloseTo(
+      (previewPoint.y / element.height) * naturalHeight,
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure coordinate transforms used by the mask preview and the image masking code are consistent across rotation and mirroring and simplify the transform logic.
- Remove unnecessary dependency on `elementsMap` when rendering the mask editor and compute coordinates directly from the image element.

### Description
- Introduce `globalToElementLocalDisplay` to convert a global point to element-local display coordinates and refactor `globalToImageLocal` to call it for reuse and clarity.
- Update `renderMaskEditor` to compute `cx`, `cy`, `width`, and `height` directly from the `ExcalidrawImageElement` and to build `savedLocalPoints` using `MaskEditor.globalToElementLocalDisplay`, removing the `elementsMap` dependency and `getElementAbsoluteCoords` usage.
- Adjust `renderMaskEditor` function signature and call sites to remove the `elementsMap` parameter.
- Add `packages/excalidraw/tests/maskEditor.test.ts` with tests that assert preview path coordinates match `applyMask` image coordinates for rotated and mirrored image elements.

### Testing
- Added unit tests in `packages/excalidraw/tests/maskEditor.test.ts` and ran them; they passed.
- Ran the repository test suite (`yarn test`) to ensure no regressions; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0734966883239b8cbbc31925b824)