### PR TITLE
Isolate mask-editor point edits from global undo and add tests

### DIFF
--- a/packages/excalidraw/actions/actionMaskEditor.tsx
+++ b/packages/excalidraw/actions/actionMaskEditor.tsx
@@ -32,7 +32,7 @@ export const actionToggleMaskEditor = register({
         selectedMaskPointIndex: null,
         isMasking: false,
       },
-      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      captureUpdate: CaptureUpdateAction.NEVER,
     };
   },
   predicate: (elements, appState, _, app) => {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -664,6 +664,10 @@ class App extends React.Component<AppProps, AppState> {
 
   private elementsPendingErasure: ElementsPendingErasure = new Set();
 
+  /**
+   * 遮罩多边形编辑的本地撤销栈。遮罩编辑器打开时，Ctrl/Cmd+Z
+   * 只从这里恢复遮罩点，避免尚未应用的临时点位进入全局历史记录。
+   */
   private maskPointHistory: GlobalPoint[][] = [];
 
   private _initialized = false;
@@ -4914,7 +4918,6 @@ class App extends React.Component<AppProps, AppState> {
             event.key === KEYS.DELETE
           ) {
             event.preventDefault();
-            this.maskPointHistory.push([...this.state.maskingPoints]);
             const newPoints =
               this.state.selectedMaskPointIndex !== null
                 ? MaskEditor.removePoint(
@@ -4922,19 +4925,28 @@ class App extends React.Component<AppProps, AppState> {
                     this.state.selectedMaskPointIndex,
                   )
                 : MaskEditor.removeLastPoint(this.state.maskingPoints);
-            this.setState({
-              maskingPoints: newPoints,
-              selectedMaskPointIndex: null,
-            });
+            if (newPoints.length !== this.state.maskingPoints.length) {
+              this.maskPointHistory.push([...this.state.maskingPoints]);
+              this.setState({
+                maskingPoints: newPoints,
+                selectedMaskPointIndex: null,
+                isMasking: false,
+              });
+            }
             return;
           }
-          if (event.key === KEYS.Z && event.ctrlKey && !event.shiftKey) {
+          if (
+            event.key === KEYS.Z &&
+            event[KEYS.CTRL_OR_CMD] &&
+            !event.shiftKey
+          ) {
             event.preventDefault();
             const prevPoints = this.maskPointHistory.pop();
             if (prevPoints) {
               this.setState({
                 maskingPoints: prevPoints,
                 selectedMaskPointIndex: null,
+                isMasking: false,
               });
             }
             return;
@@ -6548,7 +6560,8 @@ class App extends React.Component<AppProps, AppState> {
 
   private finishMasking = () => {
     if (this.state.maskingElementId) {
-      this.store.scheduleCapture();
+      this.maskPointHistory = [];
+      this.store.scheduleAction(CaptureUpdateAction.NEVER);
       this.setState({
         maskingElementId: null,
         maskingPoints: [],
@@ -6588,6 +6601,10 @@ class App extends React.Component<AppProps, AppState> {
       );
 
       if (result) {
+        flushSync(() => {
+          this.finishMasking();
+        });
+
         const newFileId =
           nanoid() as import("@excalidraw/element/types").FileId;
 
@@ -6604,6 +6621,7 @@ class App extends React.Component<AppProps, AppState> {
           fileId: newFileId,
           crop: null,
         });
+        this.store.scheduleCapture();
 
         this.clearImageShapeCache({ [newFileId]: newFileData } as BinaryFiles);
         this.scene.triggerUpdate();

--- a/packages/excalidraw/tests/maskEditor.test.tsx
+++ b/packages/excalidraw/tests/maskEditor.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { vi } from "vitest";
+
+import { KEYS } from "@excalidraw/common";
+import { CaptureUpdateAction } from "@excalidraw/element";
+
+import type { ExcalidrawImageElement, FileId } from "@excalidraw/element/types";
+
+import { actionToggleMaskEditor } from "../actions/actionMaskEditor";
+import { Excalidraw } from "../index";
+import { MaskEditor } from "../mask-editor";
+
+import { API } from "./helpers/api";
+import { Keyboard, Pointer } from "./helpers/ui";
+import { act, render, waitFor } from "./test-utils";
+
+const { h } = window;
+
+const renderEditor = async () => {
+  await render(<Excalidraw autoFocus={true} handleKeyboardGlobally={true} />);
+};
+
+const createSelectedImage = () => {
+  const image = API.createElement({
+    type: "image",
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 200,
+    fileId: "old-file" as FileId,
+  });
+
+  API.updateScene({
+    elements: [image],
+    appState: { selectedElementIds: { [image.id]: true } },
+    captureUpdate: CaptureUpdateAction.NEVER,
+  });
+  h.history.clear();
+
+  return image;
+};
+
+const startMaskEditor = () => {
+  API.executeAction(actionToggleMaskEditor);
+  expect(h.state.maskingElementId).toBe(h.elements[0].id);
+};
+
+describe("mask editor interactions", () => {
+  const pointer = new Pointer("mouse");
+
+  beforeEach(async () => {
+    await renderEditor();
+    pointer.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps point editing undo local and does not create global undo entries when canceling", () => {
+    createSelectedImage();
+    startMaskEditor();
+
+    expect(h.history.undoStack).toHaveLength(0);
+
+    pointer.clickAt(20, 20);
+    pointer.clickAt(100, 20);
+    pointer.clickAt(100, 100);
+    expect(h.state.maskingPoints).toEqual([
+      [20, 20],
+      [100, 20],
+      [100, 100],
+    ]);
+
+    pointer.downAt(20, 20);
+    pointer.moveTo(30, 30);
+    pointer.upAt(30, 30);
+    expect(h.state.maskingPoints[0]).toEqual([30, 30]);
+
+    Keyboard.keyPress(KEYS.DELETE);
+    expect(h.state.maskingPoints).toEqual([
+      [100, 20],
+      [100, 100],
+    ]);
+
+    Keyboard.undo();
+    expect(h.state.maskingPoints).toEqual([
+      [30, 30],
+      [100, 20],
+      [100, 100],
+    ]);
+
+    Keyboard.undo();
+    expect(h.state.maskingPoints).toEqual([
+      [20, 20],
+      [100, 20],
+      [100, 100],
+    ]);
+
+    Keyboard.keyPress(KEYS.ESCAPE);
+    expect(h.state.maskingElementId).toBeNull();
+    expect(h.state.maskingPoints).toEqual([]);
+    expect(h.history.undoStack).toHaveLength(0);
+
+    Keyboard.undo();
+    expect(h.elements).toHaveLength(1);
+    expect(h.elements[0].isDeleted).toBe(false);
+  });
+
+  it("keeps Backspace/Delete scoped to an active mask editor", () => {
+    createSelectedImage();
+
+    Keyboard.keyPress(KEYS.DELETE);
+    expect(h.elements[0].isDeleted).toBe(true);
+
+    Keyboard.undo();
+    expect(h.elements[0].isDeleted).toBe(false);
+
+    startMaskEditor();
+    pointer.clickAt(20, 20);
+    pointer.clickAt(100, 20);
+
+    Keyboard.keyPress(KEYS.BACKSPACE);
+    expect(h.elements[0].isDeleted).toBe(false);
+    expect(h.state.maskingPoints).toEqual([[20, 20]]);
+  });
+
+  it("captures applied masks as one global undo entry without restoring editor-only state", async () => {
+    const image = createSelectedImage();
+    const oldFileId = image.fileId;
+    startMaskEditor();
+    pointer.clickAt(20, 20);
+    pointer.clickAt(100, 20);
+    pointer.clickAt(100, 100);
+
+    vi.spyOn(MaskEditor, "applyMask").mockResolvedValue({
+      dataURL:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/luz7vwAAAABJRU5ErkJggg==",
+      newWidth: 1,
+      newHeight: 1,
+    });
+
+    Keyboard.keyPress(KEYS.ENTER);
+
+    await waitFor(() => {
+      expect(h.state.maskingElementId).toBeNull();
+      expect((h.elements[0] as ExcalidrawImageElement).fileId).not.toBe(
+        oldFileId,
+      );
+    });
+
+    expect(h.history.undoStack).toHaveLength(1);
+
+    act(() => {
+      Keyboard.undo();
+    });
+
+    await waitFor(() => {
+      expect((h.elements[0] as ExcalidrawImageElement).fileId).toBe(oldFileId);
+      expect(h.state.maskingElementId).toBeNull();
+      expect(h.state.maskingPoints).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent temporary mask-point edits from polluting the global undo stack and avoid accidental element deletion when the mask editor is active.
- Ensure applying a mask produces a single global history entry and that editor-only state is not restored by undo.

### Description

- Changed the mask editor action to open without scheduling a global capture by setting `captureUpdate` to `CaptureUpdateAction.NEVER` in `actionToggleMaskEditor`.
- Added a local `maskPointHistory` (`GlobalPoint[][]`) to `App` and updated keyboard handling so Backspace/Delete and undo (`CTRL/CMD+Z` via `KEYS.CTRL_OR_CMD`) manipulate only the local stack while editing, and only push history when points actually change.
- Cleared `maskPointHistory` on `finishMasking` and avoided scheduling a global capture while the editor is open, while scheduling a single capture after a successful `applyMask`; `applyMask` now calls `finishMasking` inside `flushSync` before creating the new file entry.
- Added `packages/excalidraw/tests/maskEditor.test.tsx` with unit tests covering local undo scoping, Backspace/Delete behavior while masking, and that applying a mask creates one global undo entry and does not restore editor-only state.

### Testing

- Ran the new mask editor unit tests in `packages/excalidraw/tests/maskEditor.test.tsx` (Vitest) and they passed.
- Ran relevant existing unit tests for editor keyboard interactions and history handling and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d07432d948323b9f767091b0e07cb)